### PR TITLE
Build: Use a composite TypeScript setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 build
 *.d.ts
+*.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "npm run build:bundle",
     "test": "npm run test:unit && npm run test:lint && npm run test:types",
     "build:bundle": "rollup -c",
-    "prebuild:types": "rimraf \"packages/**/*.+(d.ts|.tsbuildinfo)\"",
+    "prebuild:types": "rimraf \"packages/**/*.+(d.ts|tsbuildinfo)\"",
     "build:types": "tsc --build packages/*",
     "build": "npm run build:bundle && npm run build:types",
     "postinstall": "lerna bootstrap"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "npm run build:bundle",
     "test": "npm run test:unit && npm run test:lint && npm run test:types",
     "build:bundle": "rollup -c",
-    "prebuild:types": "rimraf \"packages/**/*.+(d.ts|tsbuildinfo)\"",
+    "prebuild:types": "tsc --build --clean",
     "build:types": "tsc --build --verbose",
     "build": "npm run build:bundle && npm run build:types",
     "postinstall": "lerna bootstrap"

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "scripts": {
     "test:unit": "jest",
     "test:lint": "eslint .",
-    "test:types": "tsc",
+    "test:types": "tsc --build packages/*",
     "pretest": "npm run build:bundle",
     "test": "npm run test:unit && npm run test:lint && npm run test:types",
     "build:bundle": "rollup -c",
-    "prebuild:types": "rimraf \"packages/**/*.d.ts\"",
-    "build:types": "tsc -p tsconfig.declarations.json",
+    "prebuild:types": "rimraf \"packages/**/*.d.ts\" \"packages/**/*.tsbuildinfo\"",
+    "build:types": "tsc --build packages/*",
     "build": "npm run build:bundle && npm run build:types",
     "postinstall": "lerna bootstrap"
   },

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "scripts": {
     "test:unit": "jest",
     "test:lint": "eslint .",
-    "test:types": "tsc --build packages/*",
+    "test:types": "npm run build:types",
     "pretest": "npm run build:bundle",
     "test": "npm run test:unit && npm run test:lint && npm run test:types",
     "build:bundle": "rollup -c",
     "prebuild:types": "rimraf \"packages/**/*.+(d.ts|tsbuildinfo)\"",
-    "build:types": "tsc --build packages/*",
+    "build:types": "tsc --build --verbose",
     "build": "npm run build:bundle && npm run build:types",
     "postinstall": "lerna bootstrap"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "npm run build:bundle",
     "test": "npm run test:unit && npm run test:lint && npm run test:types",
     "build:bundle": "rollup -c",
-    "prebuild:types": "rimraf \"packages/**/*.d.ts\" \"packages/**/*.tsbuildinfo\"",
+    "prebuild:types": "rimraf \"packages/**/*.+(d.ts|.tsbuildinfo)\"",
     "build:types": "tsc --build packages/*",
     "build": "npm run build:bundle && npm run build:types",
     "postinstall": "lerna bootstrap"

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false,

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -6,5 +6,5 @@
 		"noImplicitThis": false
 	},
 	"files": [ "index.js" ],
-	"references": [ { "path": "../compile" } ]
+	"references": [ { "path": "../sprintf" }, { "path": "../tannin" } ]
 }

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false,
+		"noImplicitThis": false
+	},
+	"files": ["index.js"],
+	"references": [{ "path": "../compile" }]
+}

--- a/packages/compat/tsconfig.json
+++ b/packages/compat/tsconfig.json
@@ -5,6 +5,6 @@
 		"noImplicitAny": false,
 		"noImplicitThis": false
 	},
-	"files": ["index.js"],
-	"references": [{ "path": "../compile" }]
+	"files": [ "index.js" ],
+	"references": [ { "path": "../compile" } ]
 }

--- a/packages/compile/tsconfig.json
+++ b/packages/compile/tsconfig.json
@@ -3,6 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "."
 	},
-	"files": ["index.js"],
-	"references": [{ "path": "../evaluate" }, { "path": "../postfix" }]
+	"files": [ "index.js" ],
+	"references": [ { "path": "../evaluate" }, { "path": "../postfix" } ]
 }

--- a/packages/compile/tsconfig.json
+++ b/packages/compile/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "."
 	},

--- a/packages/compile/tsconfig.json
+++ b/packages/compile/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "."
+	},
+	"files": ["index.js"],
+	"references": [{ "path": "../evaluate" }, { "path": "../postfix" }]
+}

--- a/packages/evaluate/tsconfig.json
+++ b/packages/evaluate/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false

--- a/packages/evaluate/tsconfig.json
+++ b/packages/evaluate/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false
+	},
+	"files": ["index.js"]
+}

--- a/packages/evaluate/tsconfig.json
+++ b/packages/evaluate/tsconfig.json
@@ -4,5 +4,5 @@
 		"rootDir": ".",
 		"noImplicitAny": false
 	},
-	"files": ["index.js"]
+	"files": [ "index.js" ]
 }

--- a/packages/plural-forms/tsconfig.json
+++ b/packages/plural-forms/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false

--- a/packages/plural-forms/tsconfig.json
+++ b/packages/plural-forms/tsconfig.json
@@ -4,6 +4,6 @@
 		"rootDir": ".",
 		"noImplicitAny": false
 	},
-	"files": ["index.js"],
-	"references": [{ "path": "../compile" }]
+	"files": [ "index.js" ],
+	"references": [ { "path": "../compile" } ]
 }

--- a/packages/plural-forms/tsconfig.json
+++ b/packages/plural-forms/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false
+	},
+	"files": ["index.js"],
+	"references": [{ "path": "../compile" }]
+}

--- a/packages/postfix/tsconfig.json
+++ b/packages/postfix/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false

--- a/packages/postfix/tsconfig.json
+++ b/packages/postfix/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false
+	},
+	"files": ["index.js"]
+}

--- a/packages/postfix/tsconfig.json
+++ b/packages/postfix/tsconfig.json
@@ -4,5 +4,5 @@
 		"rootDir": ".",
 		"noImplicitAny": false
 	},
-	"files": ["index.js"]
+	"files": [ "index.js" ]
 }

--- a/packages/sprintf/tsconfig.json
+++ b/packages/sprintf/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false,

--- a/packages/sprintf/tsconfig.json
+++ b/packages/sprintf/tsconfig.json
@@ -5,6 +5,5 @@
 		"noImplicitAny": false,
 		"strictNullChecks": false
 	},
-	"files": [ "index.js" ],
-	"references": [ { "path": "../compile" } ]
+	"files": [ "index.js" ]
 }

--- a/packages/sprintf/tsconfig.json
+++ b/packages/sprintf/tsconfig.json
@@ -5,6 +5,6 @@
 		"noImplicitAny": false,
 		"strictNullChecks": false
 	},
-	"files": ["index.js"],
-	"references": [{ "path": "../compile" }]
+	"files": [ "index.js" ],
+	"references": [ { "path": "../compile" } ]
 }

--- a/packages/sprintf/tsconfig.json
+++ b/packages/sprintf/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false,
+		"strictNullChecks": false
+	},
+	"files": ["index.js"],
+	"references": [{ "path": "../compile" }]
+}

--- a/packages/tannin/tsconfig.json
+++ b/packages/tannin/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"extends": "../../tsconfig.json",
+	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": ".",
 		"noImplicitAny": false,

--- a/packages/tannin/tsconfig.json
+++ b/packages/tannin/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "../../tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noImplicitAny": false,
+		"strictNullChecks": false,
+		"noImplicitReturns": false
+	},
+	"files": ["index.js"],
+	"references": [{ "path": "../plural-forms" }]
+}

--- a/packages/tannin/tsconfig.json
+++ b/packages/tannin/tsconfig.json
@@ -6,6 +6,6 @@
 		"strictNullChecks": false,
 		"noImplicitReturns": false
 	},
-	"files": ["index.js"],
-	"references": [{ "path": "../plural-forms" }]
+	"files": [ "index.js" ],
+	"references": [ { "path": "../plural-forms" } ]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"module": "esnext",
+		"moduleResolution": "node",
+		"target": "es5",
+		"composite": true,
+
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		/* This needs to be false so our types are possible to consume without setting this */
+		"esModuleInterop": false,
+		"isolatedModules": true
+	},
+	"exclude": [
+		"**/build",
+		"**/dist",
+		"**/__tests__",
+		"**/benchmark",
+		"**/node_modules"
+	]
+}

--- a/tsconfig.declarations.json
+++ b/tsconfig.declarations.json
@@ -1,8 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"noEmit": false,
-		"declaration": true,
-		"emitDeclarationOnly": true
-	}
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,32 +1,12 @@
 {
-	"compilerOptions": {
-		"allowJs": true,
-		"checkJs": true,
-		"emitDeclarationOnly": true,
-		"declaration": true,
-		"module": "esnext",
-		"moduleResolution": "node",
-		"target": "es5",
-		"composite": true,
-
-		"strict": true,
-		"strictNullChecks": true,
-		"noImplicitAny": true,
-		"noUnusedLocals": true,
-		"noUnusedParameters": true,
-		"noImplicitReturns": true,
-		"noFallthroughCasesInSwitch": true,
-
-		/* This needs to be false so our types are possible to consume without setting this */
-		"esModuleInterop": false,
-		"isolatedModules": true
-	},
 	"files": [],
-	"exclude": [
-		"**/build",
-		"**/dist",
-		"**/__tests__",
-		"**/benchmark",
-		"**/node_modules"
+	"references": [
+		{ "path": "packages/compat" },
+		{ "path": "packages/compile" },
+		{ "path": "packages/evaluate" },
+		{ "path": "packages/plural-forms" },
+		{ "path": "packages/postfix" },
+		{ "path": "packages/sprintf" },
+		{ "path": "packages/tannin" }
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
 		"declaration": true,
 		"module": "esnext",
 		"moduleResolution": "node",
-		"target": "esnext",
+		"target": "es5",
 		"composite": true,
 
 		"strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
 		"esModuleInterop": false,
 		"isolatedModules": true
 	},
-	"include": [],
+	"files": [],
 	"exclude": [
 		"**/build",
 		"**/dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,24 +2,31 @@
 	"compilerOptions": {
 		"allowJs": true,
 		"checkJs": true,
-		"noEmit": true,
-		"module": "es2015",
+		"emitDeclarationOnly": true,
+		"declaration": true,
+		"module": "esnext",
 		"moduleResolution": "node",
-		"target": "es5",
-		"baseUrl": "packages",
-		"paths": {
-			"@tannin/*": [ "*/index.js" ],
-			"tannin": [ "tannin/index.js" ]
-		}
+		"target": "esnext",
+		"composite": true,
+
+		"strict": true,
+		"strictNullChecks": true,
+		"noImplicitAny": true,
+		"noUnusedLocals": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+
+		/* This needs to be false so our types are possible to consume without setting this */
+		"esModuleInterop": false,
+		"isolatedModules": true
 	},
-	"include": [
-		"packages"
-	],
+	"include": [],
 	"exclude": [
 		"**/build",
 		"**/dist",
 		"**/__tests__",
 		"**/benchmark",
-		"node_modules"
+		"**/node_modules"
 	]
 }


### PR DESCRIPTION
Reworks TypeScript setup as composite project.

See TypeScript documentation on project references:
https://www.typescriptlang.org/docs/handbook/project-references.html

> Project references are a new feature in TypeScript 3.0 that allow you to structure your TypeScript programs into smaller pieces.
>
> By doing this, you can greatly improve build times, enforce logical separation between components, and organize your code in new and better ways.

This project has nice logical separation into several packages, the composite TypeScript setup helps to reflect that. Additionally, it allows for different packages do have differing compiler options. I've relaxed strictness only as much as necessary to get the project building without changes.