### PR TITLE
docs: removed duplicate

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ The following modules are available:
 - [`@tannin/compile`](https://www.npmjs.com/package/@tannin/compile)
 - [`@tannin/evaluate`](https://www.npmjs.com/package/@tannin/evaluate)
 - [`@tannin/plural-forms`](https://www.npmjs.com/package/@tannin/plural-forms)
-- [`@tannin/compat`](https://www.npmjs.com/package/@tannin/compat)
 - [`@tannin/postfix`](https://www.npmjs.com/package/@tannin/postfix)
 - [`@tannin/sprintf`](https://www.npmjs.com/package/@tannin/sprintf)
 


### PR DESCRIPTION
Hey! [`@tannin/compat`](https://www.npmjs.com/package/@tannin/compat) is listed twice.