### PR TITLE
Feat: Add comprehensive precision support for sprintf TypeScript types

### DIFF
--- a/packages/sprintf/__tests__/sprintf.test.ts
+++ b/packages/sprintf/__tests__/sprintf.test.ts
@@ -98,6 +98,7 @@ sprintf('Id: %(id)d, price: %(price).2f', {
 	id: 123,
 	price: 45.6789,
 });
+sprintf('precision %0.2f', 1.33);
 
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected

--- a/packages/sprintf/__tests__/sprintf.test.ts
+++ b/packages/sprintf/__tests__/sprintf.test.ts
@@ -16,10 +16,10 @@ sprintf('%f -> %f', [1.2, 1.4]);
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Hello %s', 1);
-// @ts-expect-error - argument mismatch, int expected
-sprintf('Number %d', '1');
-// @ts-expect-error - argument mismatch, float expected
-sprintf('%f', '1.2');
+// @ts-expect-error - argument mismatch, string expected
+sprintf('%s %s', 'Hello', 2);
+// @ts-expect-error - argument mismatch, string expected
+sprintf('%s %s', ['Hello', 2]);
 
 // Positional Arguments
 // / Correct
@@ -42,14 +42,6 @@ sprintf('Hello %2$d, Number %1$d, Float %3$f', 1, 1, 1.2);
 sprintf('Hello %1$s, %2$s', 1, '!');
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Hello %1$s, %2$s', [1, '!']);
-// @ts-expect-error - argument mismatch, int expected
-sprintf('Number %1$d, %2$d', '1', 2);
-// @ts-expect-error - argument mismatch, int expected
-sprintf('Number %1$d, %2$d', ['1', 2]);
-// @ts-expect-error - argument mismatch, float expected
-sprintf('%1$f, %2$f', '1.2', 1.4);
-// @ts-expect-error - argument mismatch, float expected
-sprintf('%1$f, %2$f', ['1.2', 1.4]);
 // @ts-expect-error - missing arg
 sprintf('Hello %1$s, %2$s', 'world');
 
@@ -71,39 +63,55 @@ sprintf('Hello %(name)s, Number %(num)d, Float %(float)f', {
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Hello %(name)s', { name: 1 });
-// @ts-expect-error - argument mismatch, int expected
-sprintf('Number %(num)d', { num: '1' });
-// @ts-expect-error - argument mismatch, float expected
-sprintf('Float %(num)f', { num: '1.2' });
 // @ts-expect-error - wrong named argument
 sprintf('Hello %(name)s', { punctuation: '!' });
 // @ts-expect-error - missing named argument
 sprintf('Hello %(name)s, %(punctuation)s', {
 	name: 'world',
 });
-
 // @ts-expect-error - extra named argument
 sprintf('Hello %(name)s', {
 	name: 'world',
 	punctuation: '!',
 });
+// @ts-expect-error - dot notation not supported
+sprintf('Hello %(user.name)s', { user: { name: 'John' } });
+// @ts-expect-error - named placeholders not supported with unnamed placeholders
+sprintf('%(named)s %s', { named: 'Hello' }, 'world');
+// @ts-expect-error - named placeholders not supported with positional placeholders
+sprintf('%(named)s %1$s', { named: 'Hello' }, 'world');
 
 // Precision
 // / Correct
 sprintf('Float %.2s', 'abcdef');
+sprintf('Float %.*s', 3, 'abcdef');
 sprintf('Float %.2f', [1.23456]);
 sprintf('Float %.*f', 2, 1.23456);
 sprintf('Float %.*f', [2, 1.23456]);
 sprintf('%.*f, %.*s', 2, 1.23456, 3, 'aabcdef');
 sprintf('%.*f, %.*s', [2, 1.23456, 3, 'aabcdef']);
+sprintf('%1$.*f', 2, 3.14159);
+sprintf('%1$.*s', 3, 'abcdef');
+sprintf('%1$.*f and %2$.*s', 2, 3.1415, 3, 'abcdef');
+sprintf('%1$.*f and %2$.*s', [2, 3.1415, 3, 'abcdef']);
+sprintf('Id: %(id)d, price: %(price).2f', {
+	id: 123,
+	price: 45.6789,
+});
 
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Float %.2s', 123456);
-// @ts-expect-error - argument mismatch, float expected
-sprintf('Float %.2f', ['123456']);
-// @ts-expect-error - argument mismatch, int expected for precision
+// @ts-expect-error - precision must be int
 sprintf('Float %.*f', '2', 1.23456);
+// @ts-expect-error - precision must be int
+sprintf('%2$.*f', '2', 3.1415);
+// @ts-expect-error - precision must be int
+sprintf('%.*s', '3', 'abcdef');
+// @ts-expect-error - dynamic precision not allowed on named placeholders
+sprintf('Dynamic precision not allowed on named placeholders: %(named).*f', {
+	named: 1.23456,
+});
 
 // Escaped Percent
 // / Correct
@@ -114,14 +122,42 @@ sprintf('%% %s %%', 'a');
 sprintf('%% %s %%', ['a']);
 
 // / InCorrect
-// @ts-expect-error - argument mismatch, int expected
-sprintf('Grade: %d%%d.', '100');
 // @ts-expect-error - argument mismatch, string expected
 sprintf('%s%%%s', 1, 'b');
 // @ts-expect-error - too many arguments
 sprintf('%s%%s', 'a', 'b');
 // @ts-expect-error - too few arguments
 sprintf('%s%s%s%%%s', 'a', 'b');
+// @ts-expect-error - missing substitution
+sprintf('%s%%%s%s', 'a', 'b');
+
+// Unsupported Format Specifiers
+// @ts-expect-error - unsupported: %x
+sprintf('Hex: %x', 255);
+// @ts-expect-error - unsupported: %X
+sprintf('Hex: %X', 255);
+// @ts-expect-error - unsupported: %c
+sprintf('Char: %c', 'A');
+// @ts-expect-error - unsupported: %u
+sprintf('Unsigned: %u', 42);
+// @ts-expect-error - unsupported: %e
+sprintf('Scientific: %e', 1.2);
+// @ts-expect-error - unsupported: %g
+sprintf('General float: %g', 3.14);
+// @ts-expect-error - unsupported: %p
+sprintf('Pointer: %p', {});
+// @ts-expect-error - unsupported: %o
+sprintf('Octal: %o', 8);
+
+// Flags / Width / Length
+// @ts-expect-error - unsupported: flags %+d
+sprintf('Signed: %+d', 42);
+// @ts-expect-error - unsupported: padded width
+sprintf('Padded: %5d', 42);
+// @ts-expect-error - unsupported: precision with hex
+sprintf('Hex: %.2x', 255);
+// @ts-expect-error - unsupported: length modifier
+sprintf('Long: %llf', 3.14);
 
 // Misc
 // / Correct
@@ -133,12 +169,6 @@ sprintf(b, 'world', '!');
 // / InCorrect
 // @ts-expect-error - sptintf format expected to be constant and not a dynamic string
 sprintf(a + b, 'world');
-// @ts-expect-error - int expected
-sprintf('Value: %d', false);
-// @ts-expect-error - int expected
-sprintf('Value: %d', null);
-// @ts-expect-error - int expected
-sprintf('Value: %d', undefined);
 // @ts-expect-error - string expected
 sprintf('Value: %s', 0);
 // @ts-expect-error - string expected

--- a/packages/sprintf/types/index.d.ts
+++ b/packages/sprintf/types/index.d.ts
@@ -1,87 +1,267 @@
+// ---- Base Types ----
+
 type Specifiers = {
 	s: string;
 	d: number;
 	f: number;
 };
+
 type S = keyof Specifiers;
 
+// ---- Tuple Math Utilities ----
+
+// Builds a tuple of length L
 type BuildTuple<L extends number, T extends any[] = []> = T['length'] extends L
 	? T
 	: BuildTuple<L, [any, ...T]>;
 
-type Subtract1<N extends number> = BuildTuple<N> extends [any, ...infer Rest]
-	? Rest['length']
+// Subtracts 1 from a number
+type Subtract1<N extends number> =
+	BuildTuple<N> extends [any, ...infer Rest] ? Rest['length'] : never;
+
+// Adds two numbers by building and merging tuples
+type Add<A extends number, B extends number> = [
+	...BuildTuple<A>,
+	...BuildTuple<B>,
+]['length'] extends number
+	? [...BuildTuple<A>, ...BuildTuple<B>]['length']
 	: never;
 
+// Removes escaped double-percent (%%) sequences from a format string
 type StripEscapedPercents<T extends string> =
 	T extends `${infer Head}%%${infer Tail}`
 		? `${Head}${StripEscapedPercents<Tail>}`
 		: T;
 
-type HasNamedPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%(${string})${S}${string}`
-		? true
-		: false;
+// ---- Specifier Utilities ----
 
-type HasPositionalPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%${number}$${S}${string}`
-		? true
-		: false;
+// Checks if a character is a valid format specifier
+type IsValidSpec<C extends string> = C extends S ? C : never;
 
-type HasUnnamedPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%${S}${string}` ? true : false;
+type DigitChar = '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
 
-type HasDynamicPrecisionPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%.*${S}${any}` ? true : false;
+// Extracts leading digits from a string, returns [digits, rest of string]
+type ExtractDigits<
+	T extends string,
+	Acc extends string = '',
+> = T extends `${infer First}${infer Rest}`
+	? First extends DigitChar
+		? ExtractDigits<Rest, `${Acc}${First}`>
+		: [Acc, `${First}${Rest}`]
+	: [Acc, ''];
 
-type HasStaticPrecisionPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%.${number}${S}${any}` ? true : false;
+// ---- Format Specifier Parsing ----
 
-type ExtractNamedPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%(${infer Key})${infer Spec}${infer Rest}`
-		? Spec extends S
-			? { [K in Key]: Specifiers[Spec] } & ExtractNamedPlaceholders<Rest>
+// Parses precision and format specifier, supports dynamic precision (e.g. %.*f)
+type ParsePrecisionAndSpec<T extends string> =
+	T extends `.*${infer RawSpec}${infer Rest}`
+		? IsValidSpec<RawSpec> extends infer Spec extends S
+			? ['.*', Spec, Rest]
 			: never
+		: T extends `.${infer PrecisionAndSpec}`
+			? ExtractDigits<PrecisionAndSpec> extends [
+					infer DigitsStr extends string,
+					infer RestAfterDigits extends string,
+				]
+				? RestAfterDigits extends `${infer RawSpec}${infer Rest}`
+					? IsValidSpec<RawSpec> extends infer Spec extends S
+						? [`.${DigitsStr}`, Spec, Rest]
+						: never
+					: never
+				: never
+			: T extends `${infer RawSpec}${infer Rest}`
+				? IsValidSpec<RawSpec> extends infer Spec extends S
+					? ['', Spec, Rest]
+					: never
+				: never;
+
+// ---- Positional Placeholder Parsing ----
+
+// Extracts a numeric position from format like "2$s"
+type ExtractPositionalNumber<T extends string> =
+	T extends `${infer NumStr}$${infer Rest}`
+		? NumStr extends `${number}`
+			? [NumStr, Rest]
+			: never
+		: never;
+
+// Recursively collects all positional placeholders and their expected types
+type CollectPositionalPlaceholders<
+	T extends string,
+	Collected extends Record<string, any> = {},
+> =
+	StripEscapedPercents<T> extends `${infer _}%${infer AfterPercent}`
+		? ExtractPositionalNumber<AfterPercent> extends never
+			? Collected
+			: ExtractPositionalNumber<AfterPercent> extends [
+						infer PosStr extends string,
+						infer AfterPos extends string,
+				  ]
+				? ParsePrecisionAndSpec<AfterPos> extends [
+						infer Precision extends string,
+						infer Spec extends S,
+						infer Rest extends string,
+					]
+					? IsValidSpec<Spec> extends never
+						? never
+						: Precision extends '.*'
+							? CollectPositionalPlaceholders<
+									Rest,
+									Collected & { [K in PosStr]: [number, Specifiers[Spec]] }
+								>
+							: CollectPositionalPlaceholders<
+									Rest,
+									Collected & { [K in PosStr]: Specifiers[Spec] }
+								>
+					: CollectPositionalPlaceholders<AfterPos, Collected>
+				: Collected
+		: Collected;
+
+// ---- Positional Argument Extraction ----
+
+// Gets the max index used in positional placeholders
+type GetMaxPosition<T extends Record<string, any>> = {
+	[K in keyof T]: K extends `${infer N extends number}` ? N : never;
+}[keyof T];
+
+// Computes max of a number by building up a tuple
+type Max<N extends number, A extends any[] = []> = [N] extends [
+	Partial<A>['length'],
+]
+	? A['length']
+	: Max<N, [0, ...A]>;
+
+// Builds a final tuple of arguments from the collected positional types
+type BuildPositionalTuple<
+	Collected extends { [K: number]: any },
+	MaxPos extends number,
+	CurrentPos extends number = 1,
+	Result extends any[] = [],
+> =
+	CurrentPos extends Add<MaxPos, 1>
+		? Result
+		: `${CurrentPos}` extends keyof Collected
+			? Collected[`${CurrentPos}`] extends [any, any]
+				? BuildPositionalTuple<
+						Collected,
+						MaxPos,
+						Add<CurrentPos, 1>,
+						[...Result, ...Collected[CurrentPos]]
+					>
+				: BuildPositionalTuple<
+						Collected,
+						MaxPos,
+						Add<CurrentPos, 1>,
+						[...Result, Collected[CurrentPos]]
+					>
+			: BuildPositionalTuple<
+					Collected,
+					MaxPos,
+					Add<CurrentPos, 1>,
+					[...Result, unknown]
+				>;
+
+// Main positional argument extractor
+type ExtractPositionalPlaceholders<T extends string> =
+	CollectPositionalPlaceholders<T> extends infer Collected extends Record<
+		string,
+		any
+	>
+		? keyof Collected extends never
+			? []
+			: Max<GetMaxPosition<Collected>> extends infer MaxPos extends number
+				? BuildPositionalTuple<Collected, MaxPos>
+				: []
+		: [];
+
+// ---- Unnamed Placeholder Extraction ----
+
+// Extracts unnamed placeholders like %s, %.2f, %.*d (ignores positional/named)
+type ExtractUnnamedPlaceholders<T extends string> =
+	StripEscapedPercents<T> extends `${infer _}%${infer AfterPercent}`
+		? AfterPercent extends `${infer _Num}$${infer AfterPositional}`
+			? ExtractUnnamedPlaceholders<AfterPositional> // Skip positional
+			: ParsePrecisionAndSpec<AfterPercent> extends [
+						infer Precision extends string,
+						infer Spec extends S,
+						infer Rest extends string,
+				  ]
+				? [
+						...(Precision extends '.*'
+							? [number, Specifiers[Spec]]
+							: [Specifiers[Spec]]),
+						...ExtractUnnamedPlaceholders<Rest>,
+					]
+				: []
+		: [];
+
+// ---- Named Placeholder Extraction ----
+
+// Extracts named placeholders like %(key)s, %(name).2f
+type ExtractNamedPlaceholders<T extends string> =
+	StripEscapedPercents<T> extends `${infer _}%(${infer Key})${infer AfterKey}`
+		? ParsePrecisionAndSpec<AfterKey> extends [
+				infer Precision extends string,
+				infer Spec extends S,
+				infer Rest extends string,
+			]
+			? Precision extends '.*'
+				? never // Optional: disallow dynamic precision for named
+				: { [K in Key]: Specifiers[Spec] } & ExtractNamedPlaceholders<Rest>
+			: {}
 		: {};
 
-type ExtractPositionalPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%${infer Index extends number}$${infer Spec}${infer Rest}`
-		? Spec extends S
-			? {
-					[K in Subtract1<Index>]: Specifiers[Spec];
-			  } & ExtractPositionalPlaceholders<Rest>
-			: ExtractPositionalPlaceholders<Rest>
-		:  unknown[];
+// ---- Format Type Guards ----
 
-type ExtractStaticPrecisionPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%.${infer Precision extends number}${infer Spec}${infer Rest}`
-		? Spec extends S
-			? [Specifiers[Spec], ...ExtractStaticPrecisionPlaceholders<Rest>]
-			: never
-		: [];
+// Checks if string has named placeholders
+type HasNamedPlaceholders<T extends string> =
+	StripEscapedPercents<T> extends `${infer _}%(${string})${string}`
+		? true
+		: false;
 
-type ExtractDynamicPrecisionPlaceholder<T extends string> =
-	StripEscapedPercents<T> extends `${any}%.*${infer Spec}${infer Rest}`
-		? Spec extends S
-			? [number, Specifiers[Spec], ...ExtractDynamicPrecisionPlaceholder<Rest>]
-			: never
-		: [];
+// Checks if string has positional placeholders
+type HasPositionalPlaceholders<T extends string> =
+	StripEscapedPercents<T> extends `${infer _Before}%${infer Rest}`
+		? Rest extends `${infer Index}$${infer _After}`
+			? Index extends `${number}`
+				? true
+				: HasPositionalPlaceholders<Rest>
+			: HasPositionalPlaceholders<Rest>
+		: false;
 
-type ExtractUnnamedPlaceholders<T extends string> =
-	StripEscapedPercents<T> extends `${any}%${infer Spec}${infer Rest}`
-		? Spec extends S
-			? [Specifiers[Spec], ...ExtractUnnamedPlaceholders<Rest>]
-			: never
-		: [];
+// Checks if string has unnamed placeholders
+type HasUnnamedPlaceholders<T extends string> =
+	StripEscapedPercents<T> extends `${infer _}%${infer Body}`
+		? Body extends `(${string})${string}` // Named — skip
+			? HasUnnamedPlaceholders<Body>
+			: Body extends `${number}$${string}` // Positional — skip
+				? HasUnnamedPlaceholders<Body>
+				: ParsePrecisionAndSpec<Body> extends [
+							infer _,
+							infer Spec extends S,
+							infer _,
+					  ]
+					? true
+					: HasUnnamedPlaceholders<Body>
+		: false;
 
-export type SprintfArgs<T extends string> = HasNamedPlaceholders<T> extends true
-	? [values: ExtractNamedPlaceholders<T>]
-	: HasDynamicPrecisionPlaceholders<T> extends true
-	? ExtractDynamicPrecisionPlaceholder<T>
-	: HasStaticPrecisionPlaceholders<T> extends true
-	? ExtractStaticPrecisionPlaceholders<T>
-	: HasPositionalPlaceholders<T> extends true
-	? ExtractPositionalPlaceholders<T>
-	: HasUnnamedPlaceholders<T> extends true
-	? ExtractUnnamedPlaceholders<T>
-	: [];
+// ---- Public API ----
+
+// Extracts the argument types required for a sprintf-like string
+export type SprintfArgs<T extends string> =
+	HasNamedPlaceholders<T> extends true
+		? HasPositionalPlaceholders<T> extends true
+			? [never] // Invalid: named + positional
+			: HasUnnamedPlaceholders<T> extends true
+				? [never] // Invalid: named + unnamed
+				: [values: ExtractNamedPlaceholders<T>]
+		: HasPositionalPlaceholders<T> extends true
+			? HasUnnamedPlaceholders<T> extends true
+				? [
+						...ExtractPositionalPlaceholders<T>,
+						...ExtractUnnamedPlaceholders<T>,
+					]
+				: ExtractPositionalPlaceholders<T>
+			: HasUnnamedPlaceholders<T> extends true
+				? ExtractUnnamedPlaceholders<T>
+				: [];


### PR DESCRIPTION
Closes: #22

### Description
The sprintf package's TypeScript type definitions had **naive precision support** that failed to properly handle complex format strings with static and dynamic precision specifiers in positional placeholders and named placeholders.

Alongside this it also had a object based format for positional placeholder instead of array based and didn't allowing mixing of placeholders even tho it was supported by sprintf.

**Example of broken typing:**
```typescript
sprintf('%1$s: %2$.1f%% (%3$d/%4$d)', 'Progress', 66.7, 2, 3);
// Expected: [string, number, number, number] 
// Actual: [string, any, number, number]
```

The type system was incorrectly inferring the second argument as `any` instead of `number` due to the `.1f` precision specifier not being properly parsed in positional contexts.

### How

This PR implements a refactor of the sprintf type system with:

#### **Enhanced Precision Support**
- **Static precision**: `%.2f`, `%.1s` 
- **Dynamic precision**: `%.*f`, `%.*s`
- **Positional precision**: `%1$.*f`, `%2$.1f`
- **Mixed precision combinations**: `%1$.*f and %2$.2s`
- **Named precision**: `%(named).2f`

#### **Technical Improvements**

1. **`ParsePrecisionAndSpec<T>`**: New helper type that properly parses precision specifiers:

2. **Fixed `ExtractPositionalPlaceholder`**: Now returns proper tuple types instead of object indices with unknown[] as fallback causing a lingering `& unknown[]` at end of the args.
3. **Enhanced placeholder mixing validation**: Strict detection of invalid combinations

### Test Coverage
- All precision variants (static, dynamic, positional)
- Error cases for unsupported specifiers (`%x`, `%X`, `%c`, `%u`, etc.)
- Flag and width specifier rejection (currently unsupported)
- Comprehensive placeholder mixing scenarios
- Edge cases and error conditions

### Examples

**Before**:
```typescript
sprintf('%1$.*f', 2, 3.14159); // []
```

**After**:
```typescript
sprintf('%1$.*f', 2, 3.14159);                   // [number, number] ✓
sprintf('%1$.*f and %2$.*s', 2, 3.14, 3, 'abc'); // [number, number, number, string] ✓
```