### PR TITLE
Fix unnamed placeholders extraction

### DIFF
--- a/packages/sprintf/__tests__/sprintf.test.ts
+++ b/packages/sprintf/__tests__/sprintf.test.ts
@@ -12,7 +12,8 @@ sprintf('%d %d', [1, 2]);
 sprintf('%f', 1.2);
 sprintf('%f -> %f', 1.2, 1.4);
 sprintf('%f -> %f', [1.2, 1.4]);
-
+sprintf('Test %s with $ after', 'placeholder');
+sprintf('Test $ before %s', 'placeholder');
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Hello %s', 1);

--- a/packages/sprintf/__tests__/sprintf.test.ts
+++ b/packages/sprintf/__tests__/sprintf.test.ts
@@ -12,8 +12,7 @@ sprintf('%d %d', [1, 2]);
 sprintf('%f', 1.2);
 sprintf('%f -> %f', 1.2, 1.4);
 sprintf('%f -> %f', [1.2, 1.4]);
-sprintf('Test %s with $ after', 'placeholder');
-sprintf('Test $ before %s', 'placeholder');
+
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected
 sprintf('Hello %s', 1);
@@ -37,6 +36,8 @@ sprintf('%1$f, %2$f', [1.2, 1.4]);
 sprintf('%2$f, %1$f', 1.2, 1.4);
 sprintf('%2$f, %1$f', [1.2, 1.4]);
 sprintf('Hello %2$d, Number %1$d, Float %3$f', 1, 1, 1.2);
+sprintf('Test %s with $ after', 'placeholder');
+sprintf('Test $ before %s', 'placeholder');
 
 // / InCorrect
 // @ts-expect-error - argument mismatch, string expected

--- a/packages/sprintf/types/index.d.ts
+++ b/packages/sprintf/types/index.d.ts
@@ -156,7 +156,7 @@ type ExtractPositionalPlaceholders<T extends string> =
 // Extracts unnamed placeholders like %s, %.2f, %.*d (ignores positional/named)
 type ExtractUnnamedPlaceholders<T extends string> =
 	StripEscapedPercents<T> extends `${infer _}%${infer AfterPercent}`
-		? AfterPercent extends `${infer _Num}$${infer AfterPositional}`
+		? AfterPercent extends `${infer _Num extends `${number}`}$${infer AfterPositional}`
 			? ExtractUnnamedPlaceholders<AfterPositional> // Skip positional
 			: ParsePrecisionAndSpec<AfterPercent> extends [
 						infer Precision extends string,


### PR DESCRIPTION
The unnamed placeholder logic skips positional placeholders, which it determines as:
`%` followed by anything followed by $. 

This causes strings such as: 
```
Test %s with $ after
```
to be interpreted as having a `%s with $` positional placeholder, returning `[]`. 

This PR makes the logic to determine positional placeholders more specific:
`%` followed by a number followed by $. 

